### PR TITLE
fixed pathing for via readme images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This is a mirror repository and is not monitored or maintained. See https://gitlab.com/vgg/via/ for latest updates.**
+
 # VGG Image Annotator
 
 VGG Image Annotator is a simple and standalone manual 

--- a/via-1.x.y/README.md
+++ b/via-1.x.y/README.md
@@ -13,7 +13,7 @@ and released under the BSD-2 clause [license](https://gitlab.com/vgg/via/blob/ma
 which allows it to be useful for both academic projects and commercial applications.
 
 ## Screenshots
-![Screenshot showing basic image annotation](via-1.x.y/doc/screenshots/big_ben_annotation.jpg)
+![Screenshot showing basic image annotation](doc/screenshots/big_ben_annotation.jpg)
 
 ## Download
 Detailed instructions for download of VIA are available at http://www.robots.ox.ac.uk/~vgg/software/via/

--- a/via-2.x.y/README.md
+++ b/via-2.x.y/README.md
@@ -12,9 +12,9 @@ and released under the BSD-2 clause [license](https://gitlab.com/vgg/via/blob/ma
 which allows it to be useful for both academic projects and commercial applications.
 
 ## Screenshots
-<img src="via-2.x.y/doc/screenshots/via_demo_screenshot2_via-2.0.2.jpg" alt="Screenshot showing basic image annotation" title="Screenshot showing basic image annotation" height="370">
-<img src="via-2.x.y/doc/screenshots/via_face_demo_screenshot4.jpg" alt="Screenshot of VIA being used for face annotation" title="Screenshot of VIA being used for face annotation" height="370">
-<img src="via-2.x.y/doc/screenshots/via_face_track_demo_screenshot1.jpg" alt="Screenshot of VIA being used for face track annotation" title="Screenshot of VIA being used for face track annotation" height="370">
+<img src="doc/screenshots/via_demo_screenshot2_via-2.0.2.jpg" alt="Screenshot showing basic image annotation" title="Screenshot showing basic image annotation" height="370">
+<img src="doc/screenshots/via_face_demo_screenshot4.jpg" alt="Screenshot of VIA being used for face annotation" title="Screenshot of VIA being used for face annotation" height="370">
+<img src="doc/screenshots/via_face_track_demo_screenshot1.jpg" alt="Screenshot of VIA being used for face track annotation" title="Screenshot of VIA being used for face track annotation" height="370">
 
 ## Demo
 We have created self contained demo to illustrate the usage of VIA. These demo

--- a/via-2.x.y/README.md
+++ b/via-2.x.y/README.md
@@ -90,22 +90,20 @@ If you use this software, please cite it as follows:
 **Please send all pull requests for a specific version (e.g. via-2.x.y) to their respective branch (e.g. branch via-2.x.y). All contributions made to VIA code repository will be licensed under the [BSD-2 clause license](https://gitlab.com/vgg/via/blob/master/LICENSE).**
 
 The VIA application is made up of the following three files:
- * [index.html](via-2.x.y/src/index.html) : defines the user interface components 
+ * [index.html](src/index.html) : defines the user interface components 
 like menu bar, toolbar, annotation editor, shape selector, file list, etc.
- * [via.css](via-2.x.y/src/via.css) : describes the style (e.g. colour, font size, 
-border, etc.) of user interface components defined in [index.html](via-2.x.y/src/index.html).
- * [via.js](via-2.x.y/src/via.js) : Javascript code that manages user interactions 
+ * [via.css](src/via.css) : describes the style (e.g. colour, font size, 
+border, etc.) of user interface components defined in [index.html](src/index.html).
+ * [via.js](src/via.js) : Javascript code that manages user interactions 
 (e.g. draw regions, select region shape, etc.) and other aspects of the VIA 
 application (e.g. load file, import/export annotations, edit metadata, etc.)
 
-The above three files are combined by [pack_via.py](via-2.x.y/scripts/pack_via.py)
-script to generate the final VIA application file named [via.html](via-2.x.y/dist/via.html).
+The above three files are combined by [pack_via.py](scripts/pack_via.py)
+script to generate the final VIA application file named [via.html](dist/via.html).
 
-More details about the VIA source code is available in the [source code documentation](via-2.x.y/CodeDoc.md)
-file. All the files related to the VIA application reside in the [via-2.x.y branch](https://gitlab.com/vgg/via/tree/via-2.x.y/via-2.x.y)
-of the source code repository. The [Quality Assessment](via-2.x.y/QualityAssessment.md) 
-page describes the guidelines to ensure the quality of VIA application, source 
-code and its documentation.
+More details about the VIA source code is available in the [source code documentation](CodeDoc.md)
+file. All the files related to the VIA application reside in the [via-2.x.y branch](https://gitlab.com/vgg/via/tree/via-2.x.y)
+of the source code repository.
 
 Software bug reports and feature requests should be 
 [submitted here](https://gitlab.com/vgg/via/issues/new) (requires gitlab account).

--- a/via-3.x.y/README.md
+++ b/via-3.x.y/README.md
@@ -13,8 +13,8 @@ and released under the BSD-2 clause [license](https://gitlab.com/vgg/via/blob/ma
 which allows it to be useful for both academic projects and commercial applications.
 
 ## Screenshots
-<img src="via-3.x.y/doc/screenshots/via_video_annotator.png" alt="Temporal segments showing different human activities (e.g. break egg, pour liquid, etc.) and spatial regions (e.g. bounding box of cup) occupied by different objects in a still video frame are manually delineated in a video showing preparation of a drink." title="Temporal segments showing different human activities (e.g. break egg, pour liquid, etc.) and spatial regions (e.g. bounding box of cup) occupied by different objects in a still video frame are manually delineated in a video showing preparation of a drink." height="500">
-<img src="via-3.x.y/doc/screenshots/via_audio_annotator.png" alt="Speech segments of two individuals is manually delineated in an audio recording of conversation between ATC and pilot" title="Speech segments of two individuals is manually delineated in an audio recording of conversation between ATC and pilot" height="370">
+<img src="doc/screenshots/via_video_annotator.png" alt="Temporal segments showing different human activities (e.g. break egg, pour liquid, etc.) and spatial regions (e.g. bounding box of cup) occupied by different objects in a still video frame are manually delineated in a video showing preparation of a drink." title="Temporal segments showing different human activities (e.g. break egg, pour liquid, etc.) and spatial regions (e.g. bounding box of cup) occupied by different objects in a still video frame are manually delineated in a video showing preparation of a drink." height="500">
+<img src="doc/screenshots/via_audio_annotator.png" alt="Speech segments of two individuals is manually delineated in an audio recording of conversation between ATC and pilot" title="Speech segments of two individuals is manually delineated in an audio recording of conversation between ATC and pilot" height="370">
 
 ## Download
 Detailed instructions for download of VIA3 are available at http://www.robots.ox.ac.uk/~vgg/software/via/


### PR DESCRIPTION
the previous pathing was referencing the images within the via folders twice, which lead the images in the readme to break. 
example:
previous: via/**via-3.x.y**/via-3.x.y/...
updated: via/via-3.x.y/...