### PR TITLE
Bugfix for exporting coco format, if the images have mix of chars and digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This is a mirror repository and is not monitored or maintained. See https://gitlab.com/vgg/via/ for latest updates.**
+
 # VGG Image Annotator
 
 VGG Image Annotator is a simple and standalone manual 

--- a/via-2.x.y/src/via.js
+++ b/via-2.x.y/src/via.js
@@ -1289,6 +1289,10 @@ function export_project_to_coco_format() {
       break;
     }
   }
+  const rawKeys = Object.keys(_via_img_metadata);
+  const keys = rawKeys.map(k => parseInt(k)); // parse each key to integer
+  const duplicated_image_id = new Set(keys).size !== keys.length || keys.some(id => Number.isNaN(id));
+  
   if(assign_unique_id) {
     // check if all the options have unique id
     var attribute_option_id_list = [];
@@ -1344,7 +1348,7 @@ function export_project_to_coco_format() {
     }
 
     var coco_img_id;
-    if(assign_unique_id) {
+    if(assign_unique_id || duplicated_image_id) {
       coco_img_id = unique_img_id;
       unique_img_id = unique_img_id + 1;
     } else {


### PR DESCRIPTION
If the images have a similar starting digit and then following with other chars, exporting the annotations as coco caused the image_id to be always the same. 
'20250116_120544_front.png'
This bugfix will give the image_id a uniq number.